### PR TITLE
修复频繁请求openai导致报错、单词生成文章并未包含所有单词的问题

### DIFF
--- a/.github/workflows/send_shanbay_words.yml
+++ b/.github/workflows/send_shanbay_words.yml
@@ -6,7 +6,7 @@ on:
     - cron: "*/60 */4 * * *"
   push:
     branches:
-      - master
+      - main
     paths:
       - shanbay.js
 env:

--- a/.github/workflows/send_shanbay_words.yml
+++ b/.github/workflows/send_shanbay_words.yml
@@ -17,7 +17,7 @@ jobs:
   sender:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: agu
         run: sudo apt-get update
       - name: Setup ffmpeg for differnt platforms 
@@ -26,10 +26,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x' 
+          node-version: '16.x' 
       - name: Install package
         run: |
           npm i

--- a/.github/workflows/send_shanbay_words.yml
+++ b/.github/workflows/send_shanbay_words.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - test
     paths:
       - shanbay.js
 env:

--- a/.github/workflows/send_shanbay_words.yml
+++ b/.github/workflows/send_shanbay_words.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x' 
+          node-version: '16.x' 
       - name: Install package
         run: |
           npm i

--- a/.github/workflows/send_shanbay_words.yml
+++ b/.github/workflows/send_shanbay_words.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Use Node.js 16.x
+      - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x' 
+          node-version: '14.x' 
       - name: Install package
         run: |
           npm i
@@ -41,7 +41,7 @@ jobs:
           node shanbay.js ${{ secrets.TELE_TOKEN }} ${{ secrets.TELE_CHAT_ID }} "${{ secrets.SHANBAY_COOKIE }}"
       - name: Check file existence
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: "MP3_NEW/1.mp3, MP3_REVIEW/1.mp3"
       - name: use ffmpeg combine and send

--- a/.github/workflows/send_shanbay_words.yml
+++ b/.github/workflows/send_shanbay_words.yml
@@ -3,7 +3,8 @@ name: Send shanbay today new words to telegram
 on:
   workflow_dispatch:
   schedule:
-    - cron: "*/60 */4 * * *"
+    # - cron: "*/60 */4 * * *"
+    - cron: "*/60 12,18 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/send_shanbay_words.yml
+++ b/.github/workflows/send_shanbay_words.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Use Node.js 16.x
+      - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x' 
+          node-version: '14.x' 
       - name: Install package
         run: |
           npm i

--- a/shanbay.js
+++ b/shanbay.js
@@ -445,8 +445,8 @@ async function requestShanBayPaging (materialbookId, message = "", page = 1, wor
 async function getAndSendResult(materialbookId, message = "", page = 1, wordsType="NEW") {
   
   try {
-    const resp = await requestShanBayPaging(materialbookId, message, page, wordsType)
-    if (resp.total > 0) {
+    const resultJson = await requestShanBayPaging(materialbookId, message, page, wordsType)
+    if (resultJson.total > 0) {
       const pageCount = Math.ceil(resultJson.total / 10);
       let wordsArray = [];
       const wordsObject = resultJson.objects;

--- a/shanbay.js
+++ b/shanbay.js
@@ -418,6 +418,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       results = results + chunk;
     });
     res.on("end", async function () {
+      // 只是每一页的单词
       const toDecodeData = JSON.parse(results).data
       // if you are not remember new word, send nothing
       if (!toDecodeData) {
@@ -425,6 +426,9 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       }
       const resultJson = decode(toDecodeData);
       const totalNew = resultJson.total
+      if (totalNew === 0) { // 没有单词不要发送
+        return
+      }
       console.log('resultJson ==> ', resultJson)
       const pageCount = 1// Math.ceil(resultJson.total / 10);
       let wordsArray = [];
@@ -448,7 +452,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       message += "\n";
 
       await send2telegram(message);
-      const chatGPTMessage = await chapGPT(cMessage)
+      const chatGPTMessage = await chapGPT(cMessage) // TODO: 这里需要降低频率
       // console.log('chatGPTMessage ==> ', chatGPTMessage)
       await send2telegram(chatGPTMessage);
       const articleName = mp3ArticleMap.get(wordsType)

--- a/shanbay.js
+++ b/shanbay.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const { spawn } = require('child_process');
 
 const args = process.argv.slice(2);
-console.log('args --- ', args)
+
 if (args.length < 3) {
   console.log("Please add telegram token,telegram chatId, and shanbay cookie")
   return

--- a/shanbay.js
+++ b/shanbay.js
@@ -356,7 +356,7 @@ async function send2telegram(text) {
   });
 
   req.on("error", (error) => {
-    console.error(error);
+    console.error('send2telegram ERROR', error);
   });
 
   req.write(data);

--- a/shanbay.js
+++ b/shanbay.js
@@ -498,7 +498,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
 async function main() {
   const materialbookId = await getMaterialBookIdApi()
   message = await getAndSendResult(materialbookId); // new words
-  await getAndSendResult(materialbookId, message="", page=1, wordsType="REVIEW") // old words
+  // await getAndSendResult(materialbookId, message="", page=1, wordsType="REVIEW") // old words
 }
 
 main()

--- a/shanbay.js
+++ b/shanbay.js
@@ -462,7 +462,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       });
       if (page === 1) {
         const wordsMessageType = wordsMessageMap.get(wordsType)
-        message += `Today's ${totalNew} ${wordsMessageType}\n`;
+        message += `Today's ${resultJson.total} ${wordsMessageType}\n`;
       }
       message += wordsArray.join("\n");
       const cMessage = wordsArray.join(",");

--- a/shanbay.js
+++ b/shanbay.js
@@ -32,7 +32,7 @@ async function chapGPT(words) {
       }
     ],
     });
-    console.log('--chatGPT --', response["data"]["choices"][0]["message"]["content"]);
+    // console.log('--chatGPT --', response["data"]["choices"][0]["message"]["content"]);
     return response["data"]["choices"][0]["message"]["content"]
 };
 
@@ -438,8 +438,9 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
         getAndSendResult(materialbookId, message, page, wordsType);
       } else {
         await send2telegram(message);
-        const chatGPTMessage = await chapGPT(cMessage) 
-        // await send2telegram(await chapGPT(chatGPTMessage));
+        const chatGPTMessage = await chapGPT(cMessage)
+        // console.log('chatGPTMessage ==> ', chatGPTMessage)
+        await send2telegram(chatGPTMessage);
         const articleName = mp3ArticleMap.get(wordsType)
         const child = spawn('edge-tts', ['--text', `"${chatGPTMessage}"`, '--write-media', `${articleName}_article.mp3`]);
         child.stdout.on('data', (data) => {

--- a/shanbay.js
+++ b/shanbay.js
@@ -469,7 +469,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       const cMessage = wordsArray.join(",");
       msg += "\n";
 
-      await send2telegram(message);
+      await send2telegram(msg);
       const chatGPTMessage = await chapGPT(cMessage) // TODO: 这里需要降低频率
       // console.log('chatGPTMessage ==> ', chatGPTMessage)
       await send2telegram(chatGPTMessage);

--- a/shanbay.js
+++ b/shanbay.js
@@ -355,6 +355,10 @@ async function send2telegram(text) {
     res.on("data", () => {
       console.log("succeed");
     });
+
+    res.on("end", () => {
+      console.log("send2telegram end");
+    })
   });
 
   req.on("error", (error) => {

--- a/shanbay.js
+++ b/shanbay.js
@@ -439,7 +439,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       } else {
         await send2telegram(message);
         const chatGPTMessage = await chapGPT(cMessage) 
-        await send2telegram(await chapGPT(chatGPTMessage));
+        // await send2telegram(await chapGPT(chatGPTMessage));
         const articleName = mp3ArticleMap.get(wordsType)
         const child = spawn('edge-tts', ['--text', `"${chatGPTMessage}"`, '--write-media', `${articleName}_article.mp3`]);
         child.stdout.on('data', (data) => {

--- a/shanbay.js
+++ b/shanbay.js
@@ -17,9 +17,11 @@ const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
 });
 const openai = new OpenAIApi(configuration);
-
+let count = 0
 async function chapGPT(words) {
-  console.log('words = ', words)
+  console.log(`counts => ${count}`, 'words = ', words)
+  count++
+  // TODO: 此代码调用这个接口太频繁, 会报错
   const response = await openai.createChatCompletion({
     model: "gpt-3.5-turbo",
     // copy from https://github.com/piglei/ai-vocabulary-builder
@@ -452,7 +454,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
   }
 );
   req.on("error", function (e) {
-    console.log("error");
+    console.log("getAndSendResult error", e);
   });
   req.end();
 }

--- a/shanbay.js
+++ b/shanbay.js
@@ -19,6 +19,7 @@ const configuration = new Configuration({
 const openai = new OpenAIApi(configuration);
 
 async function chapGPT(words) {
+  console.log('words = ', words)
   const response = await openai.createChatCompletion({
     model: "gpt-3.5-turbo",
     // copy from https://github.com/piglei/ai-vocabulary-builder

--- a/shanbay.js
+++ b/shanbay.js
@@ -490,7 +490,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       // return message
     }
   } catch (e) {
-
+    console.log('getAndSendResult error', e)
   }
 }
 

--- a/shanbay.js
+++ b/shanbay.js
@@ -396,6 +396,7 @@ function downloadAudio(audioUrl, audioName, wordsType) {
   });
 }
 
+// materialbookId: mnvdu
 async function getAndSendResult(materialbookId, message = "", page = 1, wordsType="NEW") {
   let results = "";
   options.path = PATH_API(page, materialbookId, wordsType);
@@ -411,6 +412,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       }
       const resultJson = decode(toDecodeData);
       const totalNew = resultJson.total
+      console.log('resultJson ==> ', resultJson)
       const pageCount = Math.ceil(resultJson.total / 10);
       let wordsArray = [];
       const wordsObject = resultJson.objects;

--- a/shanbay.js
+++ b/shanbay.js
@@ -32,7 +32,7 @@ async function chapGPT(words) {
       }
     ],
     });
-    console.log(response["data"]["choices"][0]["message"]["content"]);
+    console.log('--chatGPT --', response["data"]["choices"][0]["message"]["content"]);
     return response["data"]["choices"][0]["message"]["content"]
 };
 

--- a/shanbay.js
+++ b/shanbay.js
@@ -22,7 +22,12 @@ async function chapGPT(words) {
   const response = await openai.createChatCompletion({
     model: "gpt-3.5-turbo",
     // copy from https://github.com/piglei/ai-vocabulary-builder
-    messages: [{ role: "user", content: `Please write a short story which is less than 300 words, the story should use simple words and these special words must be included: ${words}. Also surround every special word with a single '*' character at the beginning and the end.` }],
+    messages: [
+      {
+        role: "user",
+        content: `Please write a short story which is less than 300 words, the story should use simple words and these special words must be included: ${words}. Also surround every special word with a single '*' character at the beginning and the end.` 
+      }
+    ],
     });
     console.log(response["data"]["choices"][0]["message"]["content"]);
     return response["data"]["choices"][0]["message"]["content"]

--- a/shanbay.js
+++ b/shanbay.js
@@ -460,13 +460,14 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
           i++
         }
       });
-      if (page === 1) {
-        const wordsMessageType = wordsMessageMap.get(wordsType)
-        message += `Today's ${resultJson.total} ${wordsMessageType}\n`;
-      }
-      message += wordsArray.join("\n");
+      // if (page === 1) {
+      const wordsMessageType = wordsMessageMap.get(wordsType)
+      let msg = ''
+      msg += `Today's ${page}/${pageCount} ${wordsMessageType}\n`;
+      // }
+      msg += wordsArray.join("\n");
       const cMessage = wordsArray.join(",");
-      message += "\n";
+      msg += "\n";
 
       await send2telegram(message);
       const chatGPTMessage = await chapGPT(cMessage) // TODO: 这里需要降低频率

--- a/shanbay.js
+++ b/shanbay.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const { spawn } = require('child_process');
 
 const args = process.argv.slice(2);
+console.log('args --- ', args)
 if (args.length < 3) {
   console.log("Please add telegram token,telegram chatId, and shanbay cookie")
   return

--- a/shanbay.js
+++ b/shanbay.js
@@ -397,9 +397,18 @@ function downloadAudio(audioUrl, audioName, wordsType) {
 }
 
 // materialbookId: mnvdu
+
+/**
+ * 存在的问题：
+ * 频繁请求被openai拒绝
+ * 音频不存在
+ * 只有最后10个单词生成的文章能发送到telegram
+ * 
+*/
 async function getAndSendResult(materialbookId, message = "", page = 1, wordsType="NEW") {
   let results = "";
   options.path = PATH_API(page, materialbookId, wordsType);
+  // 获取wordsType，第page页单词
   let req = https.request(options, function (res) {
     res.on("data", function (chunk) {
       results = results + chunk;
@@ -413,7 +422,7 @@ async function getAndSendResult(materialbookId, message = "", page = 1, wordsTyp
       const resultJson = decode(toDecodeData);
       const totalNew = resultJson.total
       console.log('resultJson ==> ', resultJson)
-      const pageCount = Math.ceil(resultJson.total / 10);
+      const pageCount = 1// Math.ceil(resultJson.total / 10);
       let wordsArray = [];
       const wordsObject = resultJson.objects;
       let i = (page - 1) * 10 + 1;


### PR DESCRIPTION
**问题：**

1. 如果单词数多的话，会有较高频率去请求OpenAI的借口导致429报错；
2. 生成的文章并没有包含所有的单词

**目前做了一些调整：**

1. 分页请求，10个单词一页，一页为一个流程 -- 从获取单词列表、chatgpt生成文章、发送给telegram
2. ci/cd升级，在调试的时候发现了日志的警告(有的包6、7月份会成为报错)，所以做了更新

**效果：**
![image](https://user-images.githubusercontent.com/16351920/233848521-83c8b372-7395-4c84-a7e3-0ce8529a40be.png)
