### PR TITLE
‌‌Add Custom OPENAI_BASE_URL Support

### DIFF
--- a/.github/workflows/send_shanbay_words.yml
+++ b/.github/workflows/send_shanbay_words.yml
@@ -12,6 +12,7 @@ on:
       - shanbay.js
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
   TZ: Asia/Shanghai
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Get your telegram token and chatid (please google how to)
 2. Get your shanbay cookie from webbrower
 3. Change the secrets to your own
-
+4. (Optional) To use a custom proxy URL, create the OPENAI_BASE_URL environment variable (e.g., set it to "https://example.com/v1", ensuring the URL ends with "/v1" but doesn't include a trailing slash); by default, it uses the OpenAI official API endpoint.
 ![image](https://user-images.githubusercontent.com/32453863/234186827-ea899d82-90ed-461b-b120-1e286e2dc13e.png)
 ![image](https://user-images.githubusercontent.com/15976103/100818363-f07d4100-3484-11eb-9d4c-23d4182ad4af.png)
 

--- a/shanbay.js
+++ b/shanbay.js
@@ -22,6 +22,7 @@ const api = new API(cookie);
 
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
+  basePath: process.env.OPENAI_BASE_URL || "https://api.openai.com/v1"
 });
 const openai = new OpenAIApi(configuration);
 


### PR DESCRIPTION
## 描述
这个 PR 添加了对自定义 OPENAI_BASE_URL 的支持。用户现在可以通过设置 OPENAI_BASE_URL 环境变量来指定一个自定义的 OpenAI API 中转URL。如果未设置,将继续使用默认的 OpenAI API 地址。

## 变更内容
- 在 GitHub Actions 工作流文件中添加了 OPENAI_BASE_URL 环境变量
- 修改了 Configuration 对象的初始化,以支持自定义 basePath

## 如何测试
1. 不设置 OPENAI_BASE_URL,确保脚本仍使用默认的 OpenAI API 地址
2. 设置一个自定义的 OPENAI_BASE_URL,验证脚本是否正确使用了该地址

## 对现有功能的影响
这个改动不会影响现有的功能。对于未设置 OPENAI_BASE_URL 的用户,行为将保持不变。

## 目的
用户可以使用中转apikey了。